### PR TITLE
Do not impact atom startup time.

### DIFF
--- a/lib/character-table-view.coffee
+++ b/lib/character-table-view.coffee
@@ -277,12 +277,14 @@ class CharacterTableView extends SelectListView
     @restoreFocus()
 
   showMnemonics: ->
-    @setItems @characterData.getMnemonics()
-    @show()
+    @characterData.initialized.then =>
+      @setItems @characterData.getMnemonics()
+      @show()
 
   showAll: ->
-    @setItems @characterData.getAll()
-    @show()
+    @characterData.initialized.then =>
+      @setItems @characterData.getAll()
+      @show()
 
   show: ->
     @panel ?= atom.workspace.addModalPanel(item: this)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "mnemonic",
     "digraph"
   ],
+  "activationCommands": {
+    "atom-workspace": [
+      "character-table:toggle",
+      "character-table:show-enabled-mnemonics"
+    ]
+  },
   "dependencies": {
     "atom-space-pen-views": ">=2.0.0",
     "fuzzaldrin": "^2.1.0",


### PR DESCRIPTION
This is done by delaying package activation until actual usage.

Fixes #11
